### PR TITLE
feat(movies): Create data binder and a create movies endpoint

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:ed4582b92b69928dec6d82f78d1ad64863b89e631217bfdc5c63b3066a053eea"
+  name = "github.com/creasty/defaults"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "edf4f6a95a3223dfff4eff2c404103e756fef68d"
+  version = "v1.3.0"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -26,6 +34,25 @@
   pruneopts = "UT"
   revision = "11cb265cd96c769490bea4cdc3634ea2049197f6"
   version = "v8.0.4"
+
+[[projects]]
+  digest = "1:e1ff887e232b2d8f4f7c7db15a5fac7be418025afc4dda53c59c765dbb5aa6b4"
+  name = "github.com/go-playground/locales"
+  packages = [
+    ".",
+    "currency",
+  ]
+  pruneopts = "UT"
+  revision = "f63010822830b6fe52288ee52d5a1151088ce039"
+  version = "v0.12.1"
+
+[[projects]]
+  digest = "1:e022cf244bcac1b6ef933f1a2e0adcf6a6dfd7b872d8d41e4d4179bb09a87cbc"
+  name = "github.com/go-playground/universal-translator"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b32fa301c9fe55953584134cb6853a13c87ec0a1"
+  version = "v0.16.0"
 
 [[projects]]
   digest = "1:bed9d72d596f94e65fff37f4d6c01398074a6bb1c3f3ceff963516bd01db6ff5"
@@ -61,6 +88,14 @@
   pruneopts = "UT"
   revision = "7fd9f68ece0bcb1a905fac8f1549f0083f71c51b"
   version = "v0.2.8"
+
+[[projects]]
+  digest = "1:6782ffc812e8e700e6952ede1e60487ff1fd9da489eff762985be662a7cfc431"
+  name = "github.com/leodido/go-urn"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "70078a794e8ea4b497ba7c19a78cd60f90ccf0f4"
+  version = "v1.1.0"
 
 [[projects]]
   digest = "1:8a4073008a71ff9009d35de4f9ef33bc8e814d79f284961bbbf8c5ae97fabad3"
@@ -121,6 +156,14 @@
   pruneopts = "UT"
   revision = "acf3980132bfcdc48638724e6e3d9e5749b85999"
   version = "v1.14.3"
+
+[[projects]]
+  digest = "1:700753018409094bbf9b4e19ea0e147458b3aaadf677da3a44ec082d3c075506"
+  name = "github.com/segmentio/go-snakecase"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5e4a23e7a7bf2d4ede976046611e07ffba02224c"
+  version = "v1.2.0"
 
 [[projects]]
   digest = "1:5da8ce674952566deae4dbc23d07c85caafc6cfa815b0b3e03e41979cedb8750"
@@ -203,6 +246,25 @@
   version = "v0.3.2"
 
 [[projects]]
+  digest = "1:dad6cd59e8bb8d209194efbd3850b5d054384a63061671bfc2a6b2cc0929c731"
+  name = "gopkg.in/go-playground/mold.v2"
+  packages = [
+    ".",
+    "modifiers",
+  ]
+  pruneopts = "UT"
+  revision = "6bc20ce40733e8e04c2fda4523a957dd8e198948"
+  version = "v2.2.0"
+
+[[projects]]
+  digest = "1:ee2db1a4b9111947da887ff2f8972dd2cc80906e521a2d856901fa699b4b51ee"
+  name = "gopkg.in/go-playground/validator.v9"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "884d31b8cad6a1ec877f2400d555924cea03bbea"
+  version = "v9.29.0"
+
+[[projects]]
   digest = "1:999d566ad1ae4303c456af5a155f7b42401cca4fd33552567ed9dd997b107a08"
   name = "mellium.im/sasl"
   packages = ["."]
@@ -214,13 +276,18 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/creasty/defaults",
     "github.com/go-pg/pg",
+    "github.com/go-pg/pg/orm",
     "github.com/labstack/echo",
     "github.com/lob/logger-go",
     "github.com/pkg/errors",
     "github.com/robinjoseph08/go-pg-migrations",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
+    "gopkg.in/go-playground/mold.v2",
+    "gopkg.in/go-playground/mold.v2/modifiers",
+    "gopkg.in/go-playground/validator.v9",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,3 +36,15 @@
 [[constraint]]
   name = "github.com/robinjoseph08/go-pg-migrations"
   version = "0.1.2"
+
+[[constraint]]
+  name = "gopkg.in/go-playground/validator.v9"
+  version = "9.29.0"
+
+[[constraint]]
+  name = "gopkg.in/go-playground/mold.v2"
+  version = "2.2.0"
+
+[[constraint]]
+  name = "github.com/creasty/defaults"
+  version = "1.3.0"

--- a/internal/test/context.go
+++ b/internal/test/context.go
@@ -1,0 +1,24 @@
+package test
+
+import (
+	"bytes"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo"
+)
+
+// NewContext returns a new echo.Context, and *httptest.ResponseRecorder to be
+// used for tests.
+func NewContext(t *testing.T, payload []byte, mime string, queryParamString string) (echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+
+	e := echo.New()
+	endpoint := fmt.Sprintf("/%s", queryParamString)
+	req := httptest.NewRequest(echo.GET, endpoint, bytes.NewReader(payload))
+	req.Header.Set(echo.HeaderContentType, mime)
+	rr := httptest.NewRecorder()
+	c := e.NewContext(req, rr)
+	return c, rr
+}

--- a/pkg/binder/binder.go
+++ b/pkg/binder/binder.go
@@ -1,0 +1,89 @@
+package binder
+
+import (
+    "context"
+    "fmt"
+    "net/http"
+    "reflect"
+
+    "github.com/creasty/defaults"
+    "github.com/labstack/echo"
+    "gopkg.in/go-playground/mold.v2"
+    "gopkg.in/go-playground/mold.v2/modifiers"
+    "gopkg.in/go-playground/validator.v9"
+)
+
+// Binder is a custom struct that implements the Echo Binder interface. It binds
+// to a struct, uses mold to clean up the params, and validator to validate
+// them.
+type Binder struct {
+    binder   *echo.DefaultBinder
+    conform  *mold.Transformer
+    validate *validator.Validate
+}
+
+// New initializes a new Binder instance with the appropriate validation
+// functions registered.
+func New() *Binder {
+    binder := &echo.DefaultBinder{} // echo's default binder
+    conform := modifiers.New()
+    validate := validator.New()
+
+    return &Binder{binder, conform, validate}
+}
+
+// Bind binds, modifies, and validates payloads against the given struct.
+func (b *Binder) Bind(i interface{}, c echo.Context) error {
+    // Extract values from the request in the echo.Context into our interace i.
+    // Note that we are still using the default echo binder to extract the data
+    // from the echo.Context but we are doing some extra validation in the
+    // process.
+    if err := b.binder.Bind(i, c); err != nil {
+        return err
+    }
+
+    // Modify values based on the struct tags in our interface. Most likely this
+    // is trimming whitespace from values.
+    if err := b.conform.Struct(context.Background(), i); err != nil {
+        return err
+    }
+
+    // Set any default values that we have set.
+    if err := defaults.Set(i); err != nil {
+        return err
+    }
+
+    // Validate that the values on our struct are valid. If there are any errors,
+    // format the first error and return it as an HTTP error.
+    if err := b.validate.Struct(i); err != nil {
+        errs := err.(validator.ValidationErrors)
+        msg := format(errs[0])
+        return echo.NewHTTPError(http.StatusUnprocessableEntity, msg)
+    }
+
+    return nil
+}
+
+func format(err validator.FieldError) string {
+    if err.Kind() == reflect.Int {
+        switch err.Tag() {
+        case "max":
+            return fmt.Sprintf("%s must be less than or equal to %s", err.Field(), err.Param())
+        case "min":
+            return fmt.Sprintf("%s must be at least %s", err.Field(), err.Param())
+        }
+    } else if err.Kind() == reflect.String {
+        switch err.Tag() {
+        case "max":
+            return fmt.Sprintf("%s length must be less than or equal to %s characters long", err.Field(), err.Param())
+        case "min":
+            return fmt.Sprintf("%s length must be at least %s characters long", err.Field(), err.Param())
+        }
+    }
+
+    if err.Tag() == "required" {
+        return fmt.Sprintf("%s is required", err.Field())
+    }
+
+    return err.Param()
+}

--- a/pkg/binder/binder_test.go
+++ b/pkg/binder/binder_test.go
@@ -1,0 +1,102 @@
+package binder
+
+import (
+	"testing"
+
+	"github.com/labstack/echo"
+	"github.com/shreyasj2006/goyagi/internal/test"
+	"github.com/stretchr/testify/assert"
+)
+
+type params struct {
+	Title string `json:"title" mod:"trim" validate:"required,min=5,max=8"`
+	Age   int    `json:"age" default:"21" validate:"min=18,max=99"`
+}
+
+func TestNew(t *testing.T) {
+	b := New()
+	assert.NotNil(t, b)
+	assert.NotNil(t, b.binder)
+	assert.NotNil(t, b.conform)
+	assert.NotNil(t, b.validate)
+}
+
+func TestBind(t *testing.T) {
+	b := New()
+	assert.NotNil(t, b)
+
+	t.Run("rejects invalid content types", func(tt *testing.T) {
+		payload := []byte("{}")
+		c, _ := test.NewContext(t, payload, "invalid")
+		p := params{}
+		err := b.Bind(&p, c)
+		assert.Contains(t, err.Error(), "Unsupported Media Type")
+	})
+
+	t.Run("extracts request from request", func(tt *testing.T) {
+		payload := []byte(`{"title": "banana"}`)
+		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON)
+		p := params{}
+		err := b.Bind(&p, c)
+		assert.NoError(t, err)
+		assert.Equal(t, p.Title, "banana")
+	})
+
+	t.Run("enforces required values", func(tt *testing.T) {
+		payload := []byte(`{}`)
+		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON)
+		p := params{}
+		err := b.Bind(&p, c)
+		assert.Contains(t, err.Error(), "is required")
+	})
+
+	t.Run("sets default values", func(tt *testing.T) {
+		payload := []byte(`{"title": "banana"}`)
+		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON)
+		p := params{}
+		err := b.Bind(&p, c)
+		assert.NoError(t, err)
+		assert.Equal(t, p.Age, 21)
+	})
+
+	t.Run("trims whitespace", func(tt *testing.T) {
+		payload := []byte(`{"title": "                 banana               "}`)
+		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON)
+		p := params{}
+		err := b.Bind(&p, c)
+		assert.NoError(t, err)
+		assert.Equal(t, p.Title, "banana")
+	})
+
+	t.Run("enforces min values on strings", func(tt *testing.T) {
+		payload := []byte(`{"title": "1"}`)
+		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON)
+		p := params{}
+		err := b.Bind(&p, c)
+		assert.Contains(t, err.Error(), "length must be at least 5 characters long")
+	})
+
+	t.Run("enforces max values on strings", func(tt *testing.T) {
+		payload := []byte(`{"title": "123456789"}`)
+		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON)
+		p := params{}
+		err := b.Bind(&p, c)
+		assert.Contains(t, err.Error(), "length must be less than or equal to 8 characters long")
+	})
+
+	t.Run("enforces min values on integers", func(tt *testing.T) {
+		payload := []byte(`{"title": "banana", "age": 1}`)
+		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON)
+		p := params{}
+		err := b.Bind(&p, c)
+		assert.Contains(t, err.Error(), "must be at least 18")
+	})
+
+	t.Run("enforces max values on integers", func(tt *testing.T) {
+		payload := []byte(`{"title": "banana", "age": 100}`)
+		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON)
+		p := params{}
+		err := b.Bind(&p, c)
+		assert.Contains(t, err.Error(), "must be less than or equal to 99")
+	})
+}

--- a/pkg/movies/handlers.go
+++ b/pkg/movies/handlers.go
@@ -13,11 +13,39 @@ type handler struct {
 	app application.App
 }
 
+func (h *handler) createHandler(c echo.Context) error {
+	// params is a struct that will have our payload bound and validated against
+	params := createParams{}
+	if err := c.Bind(&params); err != nil {
+		// if there is an error binding or validating the payload, return early with an error
+		return err
+	}
+
+	movie := model.Movie{
+		Title:       params.Title,
+		ReleaseDate: params.ReleaseDate,
+	}
+
+	_, err := h.app.DB.Model(&movie).Insert()
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, movie)
+}
+
 func (h *handler) listHandler(c echo.Context) error {
+	params := listParams{}
+	if err := c.Bind(&params); err != nil {
+		return err
+	}
+
 	var movies []*model.Movie
 
 	err := h.app.DB.
 		Model(&movies).
+		Limit(params.Limit).
+		Offset(params.Offset).
 		Order("id DESC").
 		Select()
 	if err != nil {

--- a/pkg/movies/handlers_test.go
+++ b/pkg/movies/handlers_test.go
@@ -1,24 +1,52 @@
 package movies
 
 import (
-	"bytes"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo"
+	"github.com/shreyasj2006/goyagi/internal/test"
 	"github.com/shreyasj2006/goyagi/pkg/application"
 	"github.com/shreyasj2006/goyagi/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+func TestCreateHandler(t *testing.T) {
+	h := newHandler(t)
+
+	t.Run("creates a new movie", func(tt *testing.T) {
+		releaseDate := time.Now()
+		payload := createParams{
+			Title:       "a new movie",
+			ReleaseDate: releaseDate,
+		}
+		payloadBytes, err := json.Marshal(payload)
+		assert.NoError(tt, err)
+		c, rr := test.NewContext(tt, payloadBytes, echo.MIMEApplicationJSON, "")
+
+		err = h.createHandler(c)
+		assert.NoError(tt, err)
+		assert.Equal(tt, http.StatusOK, rr.Code)
+
+		var movie model.Movie
+		err = json.Unmarshal(rr.Body.Bytes(), &movie)
+		require.NoError(tt, err)
+		assert.Equal(tt, movie.Title, "a new movie")
+		// If you test with assert.Equal, these times won't be equal since
+		// there will be a difference in monotonic clock.
+		// For more info, refer https://golang.org/pkg/time/#hdr-Monotonic_Clocks
+		assert.True(tt, movie.ReleaseDate.Equal(releaseDate))
+	})
+}
+
 func TestListHandler(t *testing.T) {
 	h := newHandler(t)
 
 	t.Run("lists movies on success", func(tt *testing.T) {
-		c, rr := newContext(tt, nil)
+		c, rr := test.NewContext(tt, nil, echo.MIMEApplicationJSON, "")
 
 		err := h.listHandler(c)
 		assert.NoError(tt, err)
@@ -29,13 +57,25 @@ func TestListHandler(t *testing.T) {
 		require.NoError(tt, err)
 		assert.True(tt, len(response) >= 23)
 	})
+
+	t.Run("tests list params", func(tt *testing.T) {
+		c, rr := test.NewContext(tt, nil, echo.MIMEApplicationJSON, "?limit=2")
+		err := h.listHandler(c)
+		assert.NoError(tt, err)
+		assert.Equal(tt, http.StatusOK, rr.Code)
+
+		var response []model.Movie
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		require.NoError(tt, err)
+		assert.True(tt, len(response) == 2)
+	})
 }
 
 func TestRetrieveHandler(t *testing.T) {
 	h := newHandler(t)
 
 	t.Run("retrieves movie on success", func(tt *testing.T) {
-		c, rr := newContext(tt, nil)
+		c, rr := test.NewContext(tt, nil, echo.MIMEApplicationJSON, "")
 		c.SetParamNames("id")
 		c.SetParamValues("1")
 
@@ -51,7 +91,7 @@ func TestRetrieveHandler(t *testing.T) {
 	})
 
 	t.Run("returns 404 if user isn't found", func(tt *testing.T) {
-		c, _ := newContext(tt, nil)
+		c, _ := test.NewContext(tt, nil, echo.MIMEApplicationJSON, "")
 		c.SetParamNames("id")
 		c.SetParamValues("9999")
 
@@ -67,15 +107,4 @@ func newHandler(t *testing.T) handler {
 	app, err := application.New()
 	require.NoError(t, err)
 	return handler{app}
-}
-
-// newContext returns a new echo.Context, and *httptest.ResponseRecorder to be
-// used for tests.
-func newContext(t *testing.T, payload []byte) (echo.Context, *httptest.ResponseRecorder) {
-	e := echo.New()
-	req := httptest.NewRequest(echo.GET, "/", bytes.NewReader(payload))
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	rr := httptest.NewRecorder()
-	c := e.NewContext(req, rr)
-	return c, rr
 }

--- a/pkg/movies/routes.go
+++ b/pkg/movies/routes.go
@@ -21,4 +21,5 @@ func RegisterRoutes(e *echo.Echo, app application.App) {
 
 	g.GET("", h.listHandler)
 	g.GET("/:id", h.retrieveHandler)
+	g.POST("", h.createHandler)
 }

--- a/pkg/movies/routes_test.go
+++ b/pkg/movies/routes_test.go
@@ -16,7 +16,8 @@ func TestRegisterRoutes(t *testing.T) {
 	RegisterRoutes(e, app)
 
 	routes := test.FilterRoutes(e.Routes())
-	assert.Len(t, routes, 2)
+	assert.Len(t, routes, 3)
 	assert.Contains(t, routes, "GET /movies")
 	assert.Contains(t, routes, "GET /movies/:id")
+	assert.Contains(t, routes, "POST /movies")
 }

--- a/pkg/movies/validators.go
+++ b/pkg/movies/validators.go
@@ -1,0 +1,13 @@
+package movies
+
+import "time"
+
+type createParams struct {
+	Title       string    `json:"title"        mod:"trim" validate:"required,max=35"`
+	ReleaseDate time.Time `json:"release_date"            validate:"omitempty"`
+}
+
+type listParams struct {
+	Limit  int `query:"limit"  default:"10" validate:"min=0,max=100"`
+	Offset int `query:"offset"              validate:"min=0"`
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/labstack/echo"
 	"github.com/lob/logger-go"
 	"github.com/shreyasj2006/goyagi/pkg/application"
+	"github.com/shreyasj2006/goyagi/pkg/binder"
 	"github.com/shreyasj2006/goyagi/pkg/health"
 	"github.com/shreyasj2006/goyagi/pkg/movies"
 	"github.com/shreyasj2006/goyagi/pkg/signals"
@@ -18,6 +19,9 @@ func New(app application.App) *http.Server {
 	log := logger.New()
 
 	e := echo.New()
+	b := binder.New()
+	e.Binder = b
+
 	health.RegisterRoutes(e)
 
 	srv := &http.Server{


### PR DESCRIPTION
**What/why?**
* Sets up data binders to validate request data
* Adds a POST /movies endpoint to create movies

_In hindsight, might have been better to create separate PRs for each._