### PR TITLE
feat(logger): set up logging middleware

### DIFF
--- a/pkg/binder/binder_test.go
+++ b/pkg/binder/binder_test.go
@@ -27,7 +27,7 @@ func TestBind(t *testing.T) {
 
 	t.Run("rejects invalid content types", func(tt *testing.T) {
 		payload := []byte("{}")
-		c, _ := test.NewContext(t, payload, "invalid")
+		c, _ := test.NewContext(t, payload, "invalid", "")
 		p := params{}
 		err := b.Bind(&p, c)
 		assert.Contains(t, err.Error(), "Unsupported Media Type")
@@ -35,7 +35,7 @@ func TestBind(t *testing.T) {
 
 	t.Run("extracts request from request", func(tt *testing.T) {
 		payload := []byte(`{"title": "banana"}`)
-		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON)
+		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON, "")
 		p := params{}
 		err := b.Bind(&p, c)
 		assert.NoError(t, err)
@@ -44,7 +44,7 @@ func TestBind(t *testing.T) {
 
 	t.Run("enforces required values", func(tt *testing.T) {
 		payload := []byte(`{}`)
-		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON)
+		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON, "")
 		p := params{}
 		err := b.Bind(&p, c)
 		assert.Contains(t, err.Error(), "is required")
@@ -52,7 +52,7 @@ func TestBind(t *testing.T) {
 
 	t.Run("sets default values", func(tt *testing.T) {
 		payload := []byte(`{"title": "banana"}`)
-		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON)
+		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON, "")
 		p := params{}
 		err := b.Bind(&p, c)
 		assert.NoError(t, err)
@@ -61,7 +61,7 @@ func TestBind(t *testing.T) {
 
 	t.Run("trims whitespace", func(tt *testing.T) {
 		payload := []byte(`{"title": "                 banana               "}`)
-		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON)
+		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON, "")
 		p := params{}
 		err := b.Bind(&p, c)
 		assert.NoError(t, err)
@@ -70,7 +70,7 @@ func TestBind(t *testing.T) {
 
 	t.Run("enforces min values on strings", func(tt *testing.T) {
 		payload := []byte(`{"title": "1"}`)
-		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON)
+		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON, "")
 		p := params{}
 		err := b.Bind(&p, c)
 		assert.Contains(t, err.Error(), "length must be at least 5 characters long")
@@ -78,7 +78,7 @@ func TestBind(t *testing.T) {
 
 	t.Run("enforces max values on strings", func(tt *testing.T) {
 		payload := []byte(`{"title": "123456789"}`)
-		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON)
+		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON, "")
 		p := params{}
 		err := b.Bind(&p, c)
 		assert.Contains(t, err.Error(), "length must be less than or equal to 8 characters long")
@@ -86,7 +86,7 @@ func TestBind(t *testing.T) {
 
 	t.Run("enforces min values on integers", func(tt *testing.T) {
 		payload := []byte(`{"title": "banana", "age": 1}`)
-		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON)
+		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON, "")
 		p := params{}
 		err := b.Bind(&p, c)
 		assert.Contains(t, err.Error(), "must be at least 18")
@@ -94,7 +94,7 @@ func TestBind(t *testing.T) {
 
 	t.Run("enforces max values on integers", func(tt *testing.T) {
 		payload := []byte(`{"title": "banana", "age": 100}`)
-		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON)
+		c, _ := test.NewContext(t, payload, echo.MIMEApplicationJSON, "")
 		p := params{}
 		err := b.Bind(&p, c)
 		assert.Contains(t, err.Error(), "must be less than or equal to 99")

--- a/pkg/logger/middleware.go
+++ b/pkg/logger/middleware.go
@@ -1,0 +1,88 @@
+package logger
+
+import (
+	"strings"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/labstack/echo"
+	"github.com/lob/logger-go"
+	"github.com/pkg/errors"
+)
+
+const key = "logger"
+
+// Middleware attaches a Logger instance with a request ID onto the context. It
+// also logs every request along with metadata about the request.
+func Middleware() func(next echo.HandlerFunc) echo.HandlerFunc {
+	l := logger.New()
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			// Record the time start time of the middleware invocation
+			t1 := time.Now()
+
+			// Generate a new UUID that will be used to recognize this particular
+			// request
+			id, err := uuid.NewV4()
+			if err != nil {
+				return errors.WithStack(err)
+			}
+
+			// Create a child logger with the unique UUID created and attach it to
+			// the echo.Context. By attaching it to the context it can be fetched by
+			// later middleware or handler functions to emit events with a logger
+			// that contains this ID. This is useful as it allows us to emit all
+			// events with the same request UUID.
+			log := l.ID(id.String())
+			c.Set(key, log)
+
+			// Execute the next middleware/handler function in the stack.
+			if err := next(c); err != nil {
+				c.Error(err)
+			}
+
+			// We have now succeeded executing all later middlewares in the stack and
+			// have come back to the logger middleware. Record the time at which we
+			// came back to this middleware. We can use the difference between t2 and
+			// t1 to calculate the request duration.
+			t2 := time.Now()
+
+			// Get the request IP address.
+			var ipAddress string
+			if xff := c.Request().Header.Get("x-forwarded-for"); xff != "" {
+				split := strings.Split(xff, ",")
+				ipAddress = strings.TrimSpace(split[len(split)-1])
+			} else {
+				ipAddress = c.Request().RemoteAddr
+			}
+
+			// Emit a log event with as much metadata as we can.
+			log.Root(logger.Data{
+				"status_code":   c.Response().Status,
+				"method":        c.Request().Method,
+				"path":          c.Request().URL.Path,
+				"route":         c.Path(),
+				"response_time": t2.Sub(t1).Seconds() * 1000,
+				"referer":       c.Request().Referer(),
+				"user_agent":    c.Request().UserAgent(),
+				"ip_address":    ipAddress,
+				"trace_id":      c.Request().Header.Get("x-amzn-trace-id"),
+			}).Info("request handled")
+
+			// Succeeded executing the middleware invocation. A nil response
+			// represents no errors happened.
+			return nil
+		}
+	}
+}
+
+// FromContext returns a Logger from the given echo.Context. If there is no
+// attached logger, then it will return a new Logger instance.
+func FromContext(c echo.Context) logger.Logger {
+	if log, ok := c.Get(key).(logger.Logger); ok {
+		return log
+	}
+
+	return logger.New()
+}

--- a/pkg/logger/middleware_test.go
+++ b/pkg/logger/middleware_test.go
@@ -1,0 +1,44 @@
+package logger
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo"
+	"github.com/lob/logger-go"
+	"github.com/shreyasj2006/goyagi/internal/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiddleware(t *testing.T) {
+	e := echo.New()
+	e.Use(Middleware())
+
+	e.GET("/", func(c echo.Context) error {
+		log, ok := c.Get("logger").(logger.Logger)
+		assert.True(t, ok, "expected logger to be of type Logger")
+		assert.NotNil(t, log)
+		return nil
+	})
+
+	req, err := http.NewRequest("GET", "/", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+
+	e.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestFromContext(t *testing.T) {
+	log := logger.New()
+	c, _ := test.NewContext(t, nil, echo.MIMEApplicationJSON, "")
+	c.Set(key, log)
+
+	l := FromContext(c)
+
+	assert.Equal(t, log, l)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -21,6 +21,7 @@ func New(app application.App) *http.Server {
 	e := echo.New()
 	b := binder.New()
 	e.Binder = b
+	e.Use(logger.Middleware())
 
 	health.RegisterRoutes(e)
 


### PR DESCRIPTION
**What/why?**

This PR sets up logging middleware to ensure-
* all incoming requests are assigned a ID for traceability
* standardize request logs with the following info-
```
// This is an example log blob
{  
    "level":"info",
    "host":"Shreyass-MacBook-Pro.local",
    "ip_address":"[::1]:60358",
    "method":"GET",
    "path":"/movies",
    "referer":"",
    "response_time":2.453522,
    "route":"/movies",
    "status_code":200,
    "trace_id":"",
    "user_agent":"curl/7.54.0",
    "id":"8c6b4532-95e2-41d1-b692-67c591f3fe38",
    "nanoseconds":1560276128311894000,
    "timestamp":"2019-06-11T11:02:08-07:00",
    "message":"handled request"
}
```